### PR TITLE
Remove Jest dependency

### DIFF
--- a/packages/bar/package.json
+++ b/packages/bar/package.json
@@ -3,8 +3,5 @@
   "dependencies": {
     "react": "^17.0.2",
     "react-dom": "^17.0.2"
-  },
-  "devDependencies": {
-    "jest": "^27.5.1"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,14 +7,11 @@ importers:
 
   packages/bar:
     specifiers:
-      jest: ^27.5.1
       react: ^17.0.2
       react-dom: ^17.0.2
     dependencies:
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
-    devDependencies:
-      jest: 27.5.1
 
   packages/foo:
     specifiers:


### PR DESCRIPTION
This merge conflicts with 696d5c3e820d788161e40b8caf50f12ee2a4318d.

For a version that does not merge conflict using the `workspace-consistent:` protocol
- https://github.com/gluxon/pnpm-workspace-consistent-examples/pull/2

Screenshot of GitHub merge box:

<img width="741" alt="Screen Shot 2022-03-30 at 1 34 11 AM" src="https://user-images.githubusercontent.com/906558/160758370-8e2aa589-4c25-41ce-85f1-986b0927e547.png">

```yaml
lockfileVersion: 5.3

importers:

  .:
    specifiers: {}

  packages/bar:
    specifiers:
<<<<<<< remove-jest
      react: ^17.0.2
      react-dom: ^17.0.2
    dependencies:
      react: 17.0.2
      react-dom: 17.0.2_react@17.0.2
=======
      jest: ^27.5.1
      react: ^18.0.0
      react-dom: ^18.0.0
    dependencies:
      react: 18.0.0
      react-dom: 18.0.0_react@18.0.0
    devDependencies:
      jest: 27.5.1
>>>>>>> main

  packages/foo:
    specifiers:
      react: ^18.0.0
    dependencies:
      react: 18.0.0

packages:

  # Packages section manually removed to focus on "importers" section.
```