### PR TITLE
Upgrade Jest from ^27.5.1 -> ^28.0.0-alpha.7

### DIFF
--- a/packages/bar/package.json
+++ b/packages/bar/package.json
@@ -5,6 +5,6 @@
     "react-dom": "^17.0.2"
   },
   "devDependencies": {
-    "jest": "^27.5.1"
+    "jest": "^28.0.0-alpha.7"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,14 +7,14 @@ importers:
 
   packages/bar:
     specifiers:
-      jest: ^27.5.1
+      jest: ^28.0.0-alpha.7
       react: ^17.0.2
       react-dom: ^17.0.2
     dependencies:
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
     devDependencies:
-      jest: 27.5.1
+      jest: 28.0.0-alpha.7
 
   packages/foo:
     specifiers:


### PR DESCRIPTION
This merge conflicts with 696d5c3e820d788161e40b8caf50f12ee2a4318d.

For a version that does not merge conflict using the `workspace-consistent:` protocol
- https://github.com/gluxon/pnpm-workspace-consistent-examples/pull/6

Screenshot of GitHub merge box:
<img width="766" alt="Screen Shot 2022-03-30 at 1 32 49 AM" src="https://user-images.githubusercontent.com/906558/160758220-d03dba54-bfee-47b3-aef4-eb727faa88ba.png">

```yaml
lockfileVersion: 5.3

importers:

  .:
    specifiers: {}

  packages/bar:
    specifiers:
<<<<<<< upgrade-jest
      jest: ^28.0.0-alpha.7
      react: ^17.0.2
      react-dom: ^17.0.2
=======
      jest: ^27.5.1
      react: ^18.0.0
      react-dom: ^18.0.0
>>>>>>> main
    dependencies:
      react: 18.0.0
      react-dom: 18.0.0_react@18.0.0
    devDependencies:
      jest: 28.0.0-alpha.7

  packages/foo:
    specifiers:
      react: ^18.0.0
    dependencies:
      react: 18.0.0

packages:

  # Packages section manually removed to focus on "importers" section.

```