### PR TITLE
Add react-dom to @monorepo/foo

### DIFF
--- a/packages/foo/package.json
+++ b/packages/foo/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@monorepo/foo",
   "dependencies": {
-    "react": "^17.0.2"
+    "react": "^17.0.2",
+    "react-dom": "^17.0.2"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,8 +19,10 @@ importers:
   packages/foo:
     specifiers:
       react: ^17.0.2
+      react-dom: ^17.0.2
     dependencies:
       react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
 
 packages:
 


### PR DESCRIPTION
This merge conflicts with 696d5c3e820d788161e40b8caf50f12ee2a4318d.

For a version that does not merge conflict using the `workspace-consistent:` protocol
- https://github.com/gluxon/pnpm-workspace-consistent-examples/pull/1

Screenshot of GitHub merge box:

<img width="745" alt="Screen Shot 2022-03-30 at 1 34 53 AM" src="https://user-images.githubusercontent.com/906558/160758447-efe29c54-a1ae-440d-af19-009dcd943dfd.png">


```yaml
lockfileVersion: 5.3

importers:

  .:
    specifiers: {}

  packages/bar:
    specifiers:
      jest: ^27.5.1
      react: ^18.0.0
      react-dom: ^18.0.0
    dependencies:
      react: 18.0.0
      react-dom: 18.0.0_react@18.0.0
    devDependencies:
      jest: 27.5.1

  packages/foo:
    specifiers:
<<<<<<< add-react-dom-to-foo
      react: ^17.0.2
      react-dom: ^17.0.2
    dependencies:
      react: 17.0.2
      react-dom: 17.0.2_react@17.0.2
=======
      react: ^18.0.0
    dependencies:
      react: 18.0.0
>>>>>>> main

packages:

  # Packages section manually removed to focus on "importers" section.
```