### PR TITLE
workspace-consistent: Upgrade Jest from ^27.5.1 -> ^28.0.0-alpha.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "pnpm": {
     "workspaceConsistent": {
       "versions": {
-        "jest": "^27.5.1",
+        "jest": "^28.0.0-alpha.7",
 
         "react": "^17.0.2",
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3,8 +3,8 @@ lockfileVersion: imaginary
 workspaceConsistent:
   # Spaces after each block are intentional to help git auto merge version changes.
   jest:
-    specifier: ^27.5.1
-    dependency: 27.5.1
+    specifier: ^28.0.0-alpha.7
+    dependency: 28.0.0-alpha.7
 
   react:
     specifier: ^17.0.2


### PR DESCRIPTION
Theoretical analog of the following that does not merge conflict.

- #4